### PR TITLE
Typo fixed

### DIFF
--- a/64-Bit-Verwechslung.md
+++ b/64-Bit-Verwechslung.md
@@ -1,5 +1,5 @@
 Jede Speicheradresse ist 64 Bit breit ([Bitbreite](Bitbreite.md)). Adressierung eines Datums dauert z.B. doppelt so lang gegenüber 32 Bit. **Vorteil ergibt sich erst, wenn mehr als 4 GB RAM verwendet werden.**
-Aktuelle Prozessoren verwenden zudem maximal 45 echte Adressleitungen, somit limitiert auf 45 Bit. **Maximal adressierbarer Speicher ist damit 256 TB.**
+Aktuelle Prozessoren verwenden zudem typischerweise maximal 48 echte Adressleitungen, somit limitiert auf 48 Bit. **Maximal adressierbarer Speicher ist damit 256 TB.**
 
 \#rechnerarchitekturen #betriebssysteme 
 


### PR DESCRIPTION
Changed from 45 bits to 48 bits.

Also note that Intel's 5-level paging increases physical address space from 48 bits to 57 bits, see: https://en.wikipedia.org/wiki/Intel_5-level_paging